### PR TITLE
Android App can work as a server

### DIFF
--- a/tunnel/src/main/java/com/wireguard/android/backend/GoBackend.java
+++ b/tunnel/src/main/java/com/wireguard/android/backend/GoBackend.java
@@ -78,6 +78,8 @@ public final class GoBackend implements Backend {
 
     private static native int wgTurnOn(String ifName, int tunFd, String settings);
 
+    private static native void wgEnableRoaming(boolean enabled);
+
     private static native String wgVersion();
 
     /**
@@ -253,7 +255,14 @@ public final class GoBackend implements Backend {
                 builder.addDnsServer(addr.getHostAddress());
 
             boolean sawDefaultRoute = false;
+            boolean allowRoaming = false;
             for (final Peer peer : config.getPeers()) {
+                if (!allowRoaming && !peer.getEndpoint().isPresent()) {
+                    // Allow server mode if there is a peer without an endpoint
+                    allowRoaming = true;
+                    Log.d(TAG, "Enabling roaming");
+                    wgEnableRoaming(allowRoaming);
+                }
                 for (final InetNetwork addr : peer.getAllowedIps()) {
                     if (addr.getMask() == 0)
                         sawDefaultRoute = true;

--- a/tunnel/tools/libwg-go/api-android.go
+++ b/tunnel/tools/libwg-go/api-android.go
@@ -63,6 +63,11 @@ func init() {
 	}()
 }
 
+//export wgEnableRoaming
+func wgEnableRoaming(enabled bool) {
+	device.RoamingDisabled = !enabled
+}
+
 //export wgTurnOn
 func wgTurnOn(ifnameRef string, tunFd int32, settings string) int32 {
 	interfaceName := string([]byte(ifnameRef))

--- a/tunnel/tools/libwg-go/jni.c
+++ b/tunnel/tools/libwg-go/jni.c
@@ -6,14 +6,21 @@
 #include <jni.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 
 struct go_string { const char *str; long n; };
+extern void wgEnableRoaming(bool enabled);
 extern int wgTurnOn(struct go_string ifname, int tun_fd, struct go_string settings);
 extern void wgTurnOff(int handle);
 extern int wgGetSocketV4(int handle);
 extern int wgGetSocketV6(int handle);
 extern char *wgGetConfig(int handle);
 extern char *wgVersion();
+
+JNIEXPORT void JNICALL Java_com_wireguard_android_backend_GoBackend_wgEnableRoaming(JNIEnv *env, jclass c, jboolean enabled)
+{
+    wgEnableRoaming(enabled);
+}
 
 JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_GoBackend_wgTurnOn(JNIEnv *env, jclass c, jstring ifname, jint tun_fd, jstring settings)
 {


### PR DESCRIPTION
If the WireGuard config as at least one peer without an endpoint
specified, allow the setup to work in non-roaming mode. This allows
Android devices to act as the server and be able to respond to the
handshake initiation from clients.

This change was tested on an NVIDIA Shield TV (Android version 9) to grant access to my home network. In order to get routing to work I had to run the follow (as root)
```
iptables -I FORWARD -o tun0 -j ACCEPT
iptables -I FORWARD -i tun0 -j ACCEPT
iptables -t nat -A POSTROUTING -j MASQUERADE -o eth0
sysctl -w net.ipv4.ip_forward=1
ip route add default via 192.168.4.1 dev eth0 proto static # default route to my local gateway
ip rule add unicast iif tun0 lookup main priority 999 # preempt the routing of packets coming in on the WG interface 
ip rule add unicast iif eth0 lookup main priority 29999 # allow response packets from the public interface to be routed back to WG interface
ip route flush cache
```

Since the Android app and wireguard-go implementation don't support PostUp/PostDown configurations, these commands had to be run manually.