### PR TITLE
Implemented re-resolve of endpoints when android network changes

### DIFF
--- a/tunnel/src/main/java/com/wireguard/android/backend/Backend.java
+++ b/tunnel/src/main/java/com/wireguard/android/backend/Backend.java
@@ -64,4 +64,6 @@ public interface Backend {
      * @throws Exception Exception raised while changing state.
      */
     Tunnel.State setState(Tunnel tunnel, Tunnel.State state, @Nullable Config config) throws Exception;
+
+    void reResolveEndpoints(Tunnel tunnel) throws Exception;
 }

--- a/tunnel/src/main/java/com/wireguard/android/backend/BackendException.java
+++ b/tunnel/src/main/java/com/wireguard/android/backend/BackendException.java
@@ -55,6 +55,7 @@ public final class BackendException extends Exception {
         VPN_NOT_AUTHORIZED,
         UNABLE_TO_START_VPN,
         TUN_CREATION_ERROR,
-        GO_ACTIVATION_ERROR_CODE
+        GO_ACTIVATION_ERROR_CODE,
+        RE_RESOLVE_ERROR_CODE
     }
 }

--- a/tunnel/src/main/java/com/wireguard/config/Config.java
+++ b/tunnel/src/main/java/com/wireguard/config/Config.java
@@ -182,6 +182,52 @@ public final class Config {
         return sb.toString();
     }
 
+    /**
+     * Serializes the {@code Config} for use with the WireGuard cross-platform userspace API.
+     * Specifically to be used for updating peer configuration, such as endpoints.
+     *
+     * @return the {@code Config} represented as a series of "key=value" lines
+     */
+    public String toUpdatePeersWgUserspaceString() {
+        final StringBuilder sb = new StringBuilder();
+        for (final Peer peer : peers) {
+            sb.append(peer.toWgUserspaceString());
+            sb.append("update_only=true\n");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Converts the {@code Config} into a string containing a {@code wg set} command line for updating
+     * peer endpoints.
+     *
+     * @param tunnelName name of the interface
+     * @return a wg set command line for updating peer endpoints, or null if no peer endpoints defined
+     */
+    @Nullable
+    public String toWgSetEndpointsString(final String tunnelName) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("wg ")
+                .append("set ")
+                .append('\'')
+                .append(tunnelName)
+                .append('\'');
+        boolean gotPeers = false;
+        for (final Peer peer : peers) {
+            final String peerString = peer.toWgSetEndpointString();
+            if (peerString != null) {
+                gotPeers = true;
+                sb.append(' ').append(peerString);
+            }
+        }
+
+        if (gotPeers) {
+            return sb.toString();
+        }
+
+        return null;
+    }
+
     @SuppressWarnings("UnusedReturnValue")
     public static final class Builder {
         // Defaults to an empty set.

--- a/tunnel/src/main/java/com/wireguard/config/Peer.java
+++ b/tunnel/src/main/java/com/wireguard/config/Peer.java
@@ -185,6 +185,25 @@ public final class Peer {
     }
 
     /**
+     * Converts the {@code Peer} into a string suitable for inclusion in a {@code wg set}
+     * command line for updating the endpoint.
+     *
+     * @return the {@code Peer} represented as 'peer PUBLIC_KEY endpoint ENDPOINT' or null if no
+     *         endpoint defined
+     */
+    @Nullable
+    public String toWgSetEndpointString() {
+        if (endpoint.isPresent()) {
+            return "peer " +
+                    publicKey.toBase64() +
+                    " endpoint " +
+                    endpoint.get();
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * Serializes the {@code Peer} for use with the WireGuard cross-platform userspace API. Note
      * that not all attributes are included in this representation.
      *

--- a/tunnel/src/test/java/com/wireguard/config/ConfigTest.java
+++ b/tunnel/src/test/java/com/wireguard/config/ConfigTest.java
@@ -46,4 +46,42 @@ public class ConfigTest {
         assertEquals("Test config's allowed IPs are 0.0.0.0/0 and ::0/0", config.getPeers().get(0).getAllowedIps(), expectedAllowedIps);
         assertEquals("Test config has one DNS server", 1, config.getInterface().getDnsServers().size());
     }
+
+    @Test
+    public void wg_set_returns_correct() throws IOException {
+        Config config = null;
+        try (final InputStream is = Objects.requireNonNull(getClass().getClassLoader()).getResourceAsStream("working_multiple_peers.conf")) {
+            config = Config.parse(is);
+        } catch (final BadConfigException e) {
+            fail("'working_multiple_peers.conf' should never fail to parse");
+        }
+        assertEquals(
+                "wg set 'tun' peer vBN7qyUTb5lJtWYJ8LhbPio1Z4RcyBPGnqFBGn6O6Qg= endpoint 192.0.2.1:51820 " +
+                        "peer 6IX1oZv4VWPIaa667EhfqQatdkcU8ucXJsXlC2FRlVY= endpoint 192.0.2.2:51820",
+                config.toWgSetEndpointsString("tun")
+        );
+    }
+
+    @Test
+    public void update_peers_userspace_returns_correct() throws IOException {
+        Config config = null;
+        try (final InputStream is = Objects.requireNonNull(getClass().getClassLoader()).getResourceAsStream("working_multiple_peers.conf")) {
+            config = Config.parse(is);
+        } catch (final BadConfigException e) {
+            fail("'working_multiple_peers.conf' should never fail to parse");
+        }
+        assertEquals(
+                "public_key=bc137bab25136f9949b56609f0b85b3e2a3567845cc813c69ea1411a7e8ee908\n" +
+                        "allowed_ip=0.0.0.0/0\n" +
+                        "allowed_ip=0:0:0:0:0:0:0:0/0\n" +
+                        "endpoint=192.0.2.1:51820\n" +
+                        "update_only=true\n" +
+                        "public_key=e885f5a19bf85563c869aebaec485fa906ad764714f2e71726c5e50b61519556\n" +
+                        "allowed_ip=0.0.0.0/0\n" +
+                        "allowed_ip=0:0:0:0:0:0:0:0/0\n" +
+                        "endpoint=192.0.2.2:51820\n" +
+                        "update_only=true\n",
+                config.toUpdatePeersWgUserspaceString()
+        );
+    }
 }

--- a/tunnel/src/test/resources/working_multiple_peers.conf
+++ b/tunnel/src/test/resources/working_multiple_peers.conf
@@ -1,0 +1,14 @@
+[Interface]
+Address = 192.0.2.2/32,2001:db8:ffff:ffff:ffff:ffff:ffff:ffff/128
+DNS = 192.0.2.0
+PrivateKey = TFlmmEUC7V7VtiDYLKsbP5rySTKLIZq1yn8lMqK83wo=
+[Peer]
+AllowedIPs = 0.0.0.0/0, ::0/0
+Endpoint = 192.0.2.1:51820
+PersistentKeepalive = 0
+PublicKey = vBN7qyUTb5lJtWYJ8LhbPio1Z4RcyBPGnqFBGn6O6Qg=
+[Peer]
+AllowedIPs = 0.0.0.0/0, ::0/0
+Endpoint = 192.0.2.2:51820
+PersistentKeepalive = 0
+PublicKey = 6IX1oZv4VWPIaa667EhfqQatdkcU8ucXJsXlC2FRlVY=

--- a/tunnel/tools/libwg-go/api-android.go
+++ b/tunnel/tools/libwg-go/api-android.go
@@ -200,4 +200,29 @@ func wgVersion() *C.char {
 	return C.CString(device.WireGuardGoVersion)
 }
 
+//export wgSet
+func wgSet(ifnameRef string, tunnelHandle int32, settings string) int32 {
+	handle, ok := tunnelHandles[tunnelHandle]
+	if !ok {
+		return -1
+	}
+
+	interfaceName := string([]byte(ifnameRef))
+
+	logger := &device.Logger{
+		Debug: log.New(&AndroidLogger{level: C.ANDROID_LOG_DEBUG, interfaceName: interfaceName}, "", 0),
+		Info:  log.New(&AndroidLogger{level: C.ANDROID_LOG_INFO, interfaceName: interfaceName}, "", 0),
+		Error: log.New(&AndroidLogger{level: C.ANDROID_LOG_ERROR, interfaceName: interfaceName}, "", 0),
+	}
+
+	setError := handle.device.IpcSetOperation(bufio.NewReader(strings.NewReader(settings)))
+	if setError != nil {
+		logger.Error.Println(setError)
+		return -1
+	}
+
+	logger.Info.Println("Re-resolved peer endpoints successfully")
+	return 0
+}
+
 func main() {}

--- a/tunnel/tools/libwg-go/jni.c
+++ b/tunnel/tools/libwg-go/jni.c
@@ -14,6 +14,7 @@ extern int wgGetSocketV4(int handle);
 extern int wgGetSocketV6(int handle);
 extern char *wgGetConfig(int handle);
 extern char *wgVersion();
+extern int wgSet(struct go_string ifname, int handle, struct go_string settings);
 
 JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_GoBackend_wgTurnOn(JNIEnv *env, jclass c, jstring ifname, jint tun_fd, jstring settings)
 {
@@ -68,4 +69,26 @@ JNIEXPORT jstring JNICALL Java_com_wireguard_android_backend_GoBackend_wgVersion
 	ret = (*env)->NewStringUTF(env, version);
 	free(version);
 	return ret;
+}
+
+JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_GoBackend_wgSet(JNIEnv *env, jclass c, jstring ifname, jint handle, jstring settings)
+{
+	const char *ifname_str = (*env)->GetStringUTFChars(env, ifname, 0);
+	size_t ifname_len = (*env)->GetStringUTFLength(env, ifname);
+    const char *settings_str = (*env)->GetStringUTFChars(env, settings, 0);
+    size_t settings_len = (*env)->GetStringUTFLength(env, settings);
+    int ret = wgSet(
+		(struct go_string){
+			.str = ifname_str,
+			.n = ifname_len
+		},
+        handle,
+        (struct go_string){
+            .str = settings_str,
+            .n = settings_len
+        }
+    );
+	(*env)->ReleaseStringUTFChars(env, ifname, ifname_str);
+    (*env)->ReleaseStringUTFChars(env, settings, settings_str);
+    return ret;
 }

--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="com.wireguard.android"
     android:installLocation="internalOnly">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/ui/src/main/java/com/wireguard/android/model/TunnelManager.kt
+++ b/ui/src/main/java/com/wireguard/android/model/TunnelManager.kt
@@ -210,6 +210,16 @@ class TunnelManager(private val configStore: ConfigStore) : BaseObservable() {
         newState
     }
 
+    suspend fun reResolveEndpoints() {
+        getTunnels().forEach { tunnel ->
+            if (tunnel.name in getBackend().runningTunnelNames) {
+                withContext(Dispatchers.IO) {
+                    getBackend().reResolveEndpoints(tunnel)
+                }
+            }
+        }
+    }
+
     class IntentReceiver : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent?) {
             applicationScope.launch {

--- a/ui/src/main/java/com/wireguard/android/util/ErrorMessages.kt
+++ b/ui/src/main/java/com/wireguard/android/util/ErrorMessages.kt
@@ -36,7 +36,8 @@ object ErrorMessages {
             BackendException.Reason.VPN_NOT_AUTHORIZED to R.string.vpn_not_authorized_error,
             BackendException.Reason.UNABLE_TO_START_VPN to R.string.vpn_start_error,
             BackendException.Reason.TUN_CREATION_ERROR to R.string.tun_create_error,
-            BackendException.Reason.GO_ACTIVATION_ERROR_CODE to R.string.tunnel_on_error
+            BackendException.Reason.GO_ACTIVATION_ERROR_CODE to R.string.tunnel_on_error,
+            BackendException.Reason.RE_RESOLVE_ERROR_CODE to R.string.tunnel_reresolve_error
     )
     private val KFE_FORMAT_MAP = mapOf(
             Key.Format.BASE64 to R.string.key_length_explanation_base64,

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -215,6 +215,7 @@
     <string name="tunnel_on_error">Unable to turn tunnel on (wgTurnOn returned %d)</string>
     <string name="tunnel_rename_error">Unable to rename tunnel: %s</string>
     <string name="tunnel_rename_success">Successfully renamed tunnel to “%s”</string>
+    <string name="tunnel_reresolve_error">Unable to reresolve peers (wgSet returned %d)</string>
     <string name="type_name_go_userspace">Go userspace</string>
     <string name="type_name_kernel_module">Kernel module</string>
     <string name="unknown_error">Unknown error</string>


### PR DESCRIPTION
This commit adds a re-resolving of peer endpoints when networks, such
as WiFi or Cellular, comes or goes.

I have tested the userspace implementation on my own phone but I don't
have access to a device which contains the kernel module so the
WgQuick-version is so far untested.

I also sent it as a patch to the mailing list if that is preferred but it's awaiting
moderation approval.