### PR TITLE
Fix non-translatable part of "Go userspace" in Russian

### DIFF
--- a/ui/src/main/res/values-ru/strings.xml
+++ b/ui/src/main/res/values-ru/strings.xml
@@ -242,7 +242,7 @@
     <string name="tunnel_on_error">Не удалось включить туннель (wgTurnOn вернул %d)</string>
     <string name="tunnel_rename_error">Не удалось переименовать туннель: %s</string>
     <string name="tunnel_rename_success">Туннель успешно переименован в “%s”</string>
-    <string name="type_name_go_userspace">Перейти в пользовательское пространство</string>
+    <string name="type_name_go_userspace">Пользовательское пространство Go</string>
     <string name="type_name_kernel_module">Модуль ядра</string>
     <string name="unknown_error">Неизвестная ошибка</string>
     <string name="version_summary">%1$s бэкэнд %2$s</string>


### PR DESCRIPTION
Sorry for this, I don't want to register at Crowdin just to commit single line change. If possible, copy the change there. Thanks.