### PR TITLE
Fix solution for launching the service pre-8.0 devices.

### DIFF
--- a/tunnel/src/main/java/com/wireguard/android/backend/GoBackend.java
+++ b/tunnel/src/main/java/com/wireguard/android/backend/GoBackend.java
@@ -219,7 +219,11 @@ public final class GoBackend implements Backend {
             final VpnService service;
             if (!vpnService.isDone()) {
                 Log.d(TAG, "Requesting to start VpnService");
-                context.startService(new Intent(context, VpnService.class));
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(new Intent(context, VpnService.class));
+                } else {
+                    context.startService(new Intent(context, VpnService.class));
+                }
             }
 
             try {


### PR DESCRIPTION
Fix for the following error that occurs when launching the service from background (onBoot f.e.): 
`E/WireGuard/TunnelManager: java.lang.IllegalStateException: Not allowed to start service Intent { cmp=com.tun.android.debug/com.wireguard.android.backend.GoBackend$VpnService }: app is in background`
