### PR TITLE
ui: add margin on empty list text

### DIFF
--- a/ui/src/main/res/layout/tunnel_list_fragment.xml
+++ b/ui/src/main/res/layout/tunnel_list_fragment.xml
@@ -60,6 +60,8 @@
                 android:src="@mipmap/ic_launcher" />
 
             <TextView
+                android:layout_marginStart="@dimen/tunnel_list_placeholder_margin"
+                android:layout_marginEnd="@dimen/tunnel_list_placeholder_margin"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"

--- a/ui/src/main/res/values/dimens.xml
+++ b/ui/src/main/res/values/dimens.xml
@@ -6,4 +6,5 @@
     <dimen name="normal_margin">8dp</dimen>
     <dimen name="bottom_sheet_top_padding">8dp</dimen>
     <dimen name="bottom_sheet_icon_padding">16dp</dimen>
+    <dimen name="tunnel_list_placeholder_margin">16dp</dimen>
 </resources>


### PR DESCRIPTION
Because there is no margin on the placeholder text it can be at the edge of the screen on languages where the text is longer: 
<img src="https://user-images.githubusercontent.com/18013884/149661442-0662f314-35b0-482c-b6af-a06d7fda40ee.png" width="200" />
<img src="https://user-images.githubusercontent.com/18013884/149661612-41a35925-d0c2-4de2-8737-77fc6f113cb0.png" width="200" />
This change adds a margin of 16dp at the start and end of the text for proper centering.
Screenshots taken on a Google Pixel 4a running Android 12.

