### PR TITLE
Part of the filename as a tunnel name

### DIFF
--- a/ui/src/main/java/com/wireguard/android/util/TunnelImporter.kt
+++ b/ui/src/main/java/com/wireguard/android/util/TunnelImporter.kt
@@ -59,7 +59,6 @@ object TunnelImporter {
                         name = matcher.group();
                     }
                 }
-
             } else {
                 require(isZip) { context.getString(R.string.bad_extension_error) }
             }

--- a/ui/src/main/java/com/wireguard/android/util/TunnelImporter.kt
+++ b/ui/src/main/java/com/wireguard/android/util/TunnelImporter.kt
@@ -12,6 +12,7 @@ import android.util.Log
 import androidx.fragment.app.FragmentManager
 import com.wireguard.android.Application
 import com.wireguard.android.R
+import com.wireguard.android.backend.Tunnel
 import com.wireguard.android.fragment.ConfigNamingDialogFragment
 import com.wireguard.android.model.ObservableTunnel
 import com.wireguard.config.Config
@@ -52,6 +53,13 @@ object TunnelImporter {
             val isZip = name.lowercase().endsWith(".zip")
             if (name.lowercase().endsWith(".conf")) {
                 name = name.substring(0, name.length - ".conf".length)
+                if(Tunnel.isNameInvalid(name)) {
+                    val matcher = Tunnel.NAME_PATTERN.matcher(name)
+                    if(matcher.find()){
+                        name = matcher.group();
+                    }
+                }
+
             } else {
                 require(isZip) { context.getString(R.string.bad_extension_error) }
             }


### PR DESCRIPTION
**Describe the bug**
I wanted to import a configuration file named `config_wireguard_rcIsB92hNw.conf` but it throws me the error `Invalid name`.

**To Reproduce**
Steps to reproduce the behavior:
1. Click on 'add'
2. Select `Import from file or archive`
3. Select the given file
4. See the error


**Solution**
For a better user experience, it would be great to use a substring of the filename as the tunnel name.

**wireguard-android version:** v1.0.20211029
