### PR TITLE
Exclude TunnelToggleActivity from recents

### DIFF
--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -41,7 +41,8 @@
 
         <activity
             android:name=".activity.TunnelToggleActivity"
-            android:theme="@style/NoBackgroundTheme" />
+            android:theme="@style/NoBackgroundTheme"
+            android:excludeFromRecents="true"/>
 
         <activity android:name=".activity.MainActivity">
             <intent-filter>


### PR DESCRIPTION
Fixes annoying behavior in quick settings widget, when you enable
the tunnel, try to switch to last used app, but instead it switches to
the toggle activity and turns the tunnel off.