### PR TITLE
Fix tunnel toggle activity showing up in recents

### DIFF
--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -42,6 +42,7 @@
         <activity
             android:name=".activity.TunnelToggleActivity"
             android:theme="@style/NoBackgroundTheme"
+            android:taskAffinity="${applicationId}.TunnelToggle"
             android:excludeFromRecents="true"/>
 
         <activity android:name=".activity.MainActivity">


### PR DESCRIPTION
Hopefully fixes this annoying thing that toggles the VPN when you inevitably accidentally open it. I say hopefully because I didn't test it myself as it insists on downloading a specific x86-only NDK version I don't want to download.

![Screenshot_20220402-140251](https://user-images.githubusercontent.com/1478258/161380316-8e3abff7-e63e-4834-a7d5-2e85bf691adb.png)

Really though, this shouldn't be an activity in the first place. You should be able to start the service straight from a QS tile.