### PR TITLE
SDK 31 support

### DIFF
--- a/tunnel/build.gradle
+++ b/tunnel/build.gradle
@@ -6,14 +6,14 @@ version wireguardVersionName
 group groupName
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode wireguardVersionCode
         versionName wireguardVersionName
     }

--- a/tunnel/src/main/AndroidManifest.xml
+++ b/tunnel/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
     <application>
         <service
             android:name="com.wireguard.android.backend.GoBackend$VpnService"
-            android:permission="android.permission.BIND_VPN_SERVICE">
+            android:permission="android.permission.BIND_VPN_SERVICE"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>


### PR DESCRIPTION
Fixed : com.wireguard.android.backend.GoBackend$VpnService: Targeting S+ (version 31 and above) requires that an explicit value for android:exported be defined when intent filters are present]