### PR TITLE
Add barrier to fix detail fragment overlap

### DIFF
--- a/ui/src/main/res/layout/tunnel_detail_fragment.xml
+++ b/ui/src/main/res/layout/tunnel_detail_fragment.xml
@@ -221,7 +221,6 @@
                         style="@style/DetailText"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginBottom="8dp"
                         android:contentDescription="@string/listen_port"
                         android:nextFocusRight="@id/mtu_text"
                         android:nextFocusUp="@id/dns_search_domains_text"
@@ -230,7 +229,6 @@
                         android:onClick="@{ClipboardUtils::copyTextView}"
                         android:text="@{config.interface.listenPort}"
                         android:visibility="@{!config.interface.listenPort.isPresent() ? android.view.View.GONE : android.view.View.VISIBLE}"
-                        app:layout_constraintBottom_toTopOf="@id/applications_label"
                         app:layout_constraintEnd_toStartOf="@id/mtu_label"
                         app:layout_constraintHorizontal_weight="0.5"
                         app:layout_constraintStart_toStartOf="parent"
@@ -256,7 +254,6 @@
                         style="@style/DetailText"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginBottom="8dp"
                         android:contentDescription="@string/mtu"
                         android:nextFocusLeft="@id/listen_port_text"
                         android:nextFocusUp="@id/dns_servers_text"
@@ -264,13 +261,19 @@
                         android:onClick="@{ClipboardUtils::copyTextView}"
                         android:text="@{config.interface.mtu}"
                         android:visibility="@{!config.interface.mtu.isPresent() ? android.view.View.GONE : android.view.View.VISIBLE}"
-                        app:layout_constraintBottom_toTopOf="@id/applications_label"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintHorizontal_weight="0.5"
                         app:layout_constraintStart_toEndOf="@id/listen_port_label"
                         app:layout_constraintStart_toStartOf="@+id/mtu_label"
                         app:layout_constraintTop_toBottomOf="@+id/mtu_label"
                         tools:text="1500" />
+
+                    <androidx.constraintlayout.widget.Barrier
+                        android:id="@+id/listen_port_and_mtu_barrier"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:barrierDirection="bottom"
+                        app:constraint_referenced_ids="listen_port_text,mtu_text" />
 
                     <TextView
                         android:id="@+id/applications_label"
@@ -280,7 +283,7 @@
                         android:labelFor="@+id/applications_text"
                         android:text="@string/applications"
                         android:visibility="@{config.interface.includedApplications.isEmpty() &amp;&amp; config.interface.excludedApplications.isEmpty() ? android.view.View.GONE : android.view.View.VISIBLE}"
-                        app:layout_constraintBottom_toTopOf="@id/applications_text"
+                        app:layout_constraintTop_toBottomOf="@+id/listen_port_and_mtu_barrier"
                         app:layout_constraintStart_toStartOf="parent" />
 
                     <TextView
@@ -295,7 +298,7 @@
                         android:onClick="@{ClipboardUtils::copyTextView}"
                         android:text="@{config.interface.includedApplications.isEmpty() ? @plurals/n_excluded_applications(config.interface.excludedApplications.size(), config.interface.excludedApplications.size()) : @plurals/n_included_applications(config.interface.includedApplications.size(), config.interface.includedApplications.size())}"
                         android:visibility="@{config.interface.includedApplications.isEmpty() &amp;&amp; config.interface.excludedApplications.isEmpty() ? android.view.View.GONE : android.view.View.VISIBLE}"
-                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/applications_label"
                         app:layout_constraintStart_toStartOf="parent"
                         tools:text="8 excluded" />
                 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This error was previously fixed but partially, continuing to happen when the listen port and MTU are hidden.