### PR TITLE
set `exported` value of to false

### DIFF
--- a/tunnel/src/main/AndroidManifest.xml
+++ b/tunnel/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         <service
             android:name="com.wireguard.android.backend.GoBackend$VpnService"
             android:permission="android.permission.BIND_VPN_SERVICE"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>


### PR DESCRIPTION
There is no reason to expose this service to external apps.[1]

[1] https://developer.android.com/guide/topics/manifest/activity-element#exported

Signed-off-by: Hwanseung Lee <hwanseung@chromium.org>