### PR TITLE
Small fixes to compile correctly

### DIFF
--- a/tunnel/build.gradle
+++ b/tunnel/build.gradle
@@ -6,7 +6,7 @@ version wireguardVersionName
 group groupName
 
 android {
-    compileSdkVersion 31
+    compileSdk 33
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/tunnel/build.gradle
+++ b/tunnel/build.gradle
@@ -7,6 +7,7 @@ group groupName
 
 android {
     compileSdk 33
+    ndkVersion '21.4.7075529'
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -12,7 +12,7 @@ group groupName
 final def keystorePropertiesFile = rootProject.file("keystore.properties")
 
 android {
-    compileSdkVersion 31
+    compileSdk 33
     buildFeatures {
         buildConfig = true
         dataBinding = true

--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -21,6 +21,9 @@
     <uses-feature
         android:name="android.hardware.camera.any"
         android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
 
     <permission
         android:name="${applicationId}.permission.CONTROL_TUNNELS"
@@ -44,7 +47,7 @@
             android:theme="@style/NoBackgroundTheme"
             android:excludeFromRecents="true"/>
 
-        <activity android:name=".activity.MainActivity">
+        <activity android:name=".activity.MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -58,7 +61,8 @@
 
         <activity
             android:name=".activity.TvMainActivity"
-            android:theme="@style/TvTheme">
+            android:theme="@style/TvTheme"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
@@ -82,7 +86,8 @@
 
         <activity
             android:name=".activity.LogViewerActivity"
-            android:label="@string/log_viewer_title">
+            android:label="@string/log_viewer_title"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
             </intent-filter>
@@ -94,7 +99,7 @@
             android:exported="false"
             android:grantUriPermissions="true" />
 
-        <receiver android:name=".BootShutdownReceiver">
+        <receiver android:name=".BootShutdownReceiver" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.ACTION_SHUTDOWN" />
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
@@ -103,7 +108,8 @@
 
         <receiver
             android:name=".model.TunnelManager$IntentReceiver"
-            android:permission="${applicationId}.permission.CONTROL_TUNNELS">
+            android:permission="${applicationId}.permission.CONTROL_TUNNELS"
+            android:exported="true">
             <intent-filter>
                 <action android:name="com.wireguard.android.action.REFRESH_TUNNEL_STATES" />
                 <action android:name="com.wireguard.android.action.SET_TUNNEL_UP" />
@@ -114,7 +120,8 @@
         <service
             android:name=".QuickTileService"
             android:icon="@drawable/ic_tile"
-            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />


### PR DESCRIPTION
Some libraries that were updated need an updated version of the SDK to work, in this case I updated to SDK 33 and took the opportunity to make some corrections in AndroidManifest.

The SDK update caused the app to use a newer version of the NDK and this caused problems compiling libwg-go, to avoid further inconvenience the older version of the NDK will be used until a better solution is found.