### PR TITLE
tools: fixup the CMake custom command for elf-cleaner to correctly find sources

### DIFF
--- a/tunnel/tools/CMakeLists.txt
+++ b/tunnel/tools/CMakeLists.txt
@@ -31,7 +31,7 @@ add_custom_target(libwg-go.so WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/lib
 )
 
 # Strip unwanted ELF sections to prevent DT_FLAGS_1 warnings on old Android versions
-file(GLOB ELF_CLEANER_SOURCES elf-cleaner/*.c elf-cleaner/*.cpp)
+file(GLOB ELF_CLEANER_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/elf-cleaner/*.c ${CMAKE_CURRENT_SOURCE_DIR}/elf-cleaner/*.cpp)
 add_custom_target(elf-cleaner COMMENT "Building elf-cleaner" VERBATIM COMMAND cc
         -O2 -DPACKAGE_NAME="elf-cleaner" -DPACKAGE_VERSION="" -DCOPYRIGHT=""
         -o "${CMAKE_CURRENT_BINARY_DIR}/elf-cleaner" ${ELF_CLEANER_SOURCES}


### PR DESCRIPTION
This is a tiny change to allow elf-cleaner to build correctly during assembleRelease. 

Without this I got failures to find these files with the latest Android Studio (and on the command line) - the glob found no files so the build command was malformed.