### PR TITLE
ui: Implement support for Android Dynamic Shortcuts

### DIFF
--- a/ui/sampledata/interface_names.json
+++ b/ui/sampledata/interface_names.json
@@ -28,6 +28,19 @@
         { "checked":  true },
         { "checked":  false },
         { "checked":  true }
+      ],
+      "shortcut": [
+        { "shortcut":  true },
+        { "shortcut":  false },
+        { "shortcut":  false },
+        { "shortcut":  false },
+        { "shortcut":  false },
+        { "shortcut":  false },
+        { "shortcut":  true },
+        { "shortcut":  true },
+        { "shortcut":  true },
+        { "shortcut":  false },
+        { "shortcut":  false }
       ]
     }
   ]

--- a/ui/src/main/java/com/wireguard/android/activity/TunnelToggleActivity.kt
+++ b/ui/src/main/java/com/wireguard/android/activity/TunnelToggleActivity.kt
@@ -22,18 +22,27 @@ import com.wireguard.android.backend.Tunnel
 import com.wireguard.android.util.ErrorMessages
 import kotlinx.coroutines.launch
 
-@RequiresApi(Build.VERSION_CODES.N)
 class TunnelToggleActivity : AppCompatActivity() {
     private val permissionActivityResultLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { toggleTunnelWithPermissionsResult() }
 
     private fun toggleTunnelWithPermissionsResult() {
-        val tunnel = Application.getTunnelManager().lastUsedTunnel ?: return
         lifecycleScope.launch {
+            val tunnelAction = when(intent.action) {
+                "com.wireguard.android.action.SET_TUNNEL_UP" -> Tunnel.State.UP
+                "com.wireguard.android.action.SET_TUNNEL_DOWN" -> Tunnel.State.DOWN
+                else -> Tunnel.State.TOGGLE // Implicit toggle to keep previous behaviour
+            }
+
+            val tunnel = when(val tunnelName = intent.getStringExtra("tunnel")) {
+                null -> Application.getTunnelManager().lastUsedTunnel
+                else -> Application.getTunnelManager().getTunnels().find { it.name == tunnelName }
+            } ?: return@launch // If we failed to identify the tunnel, just return
+
             try {
-                tunnel.setStateAsync(Tunnel.State.TOGGLE)
+                tunnel.setStateAsync(tunnelAction)
             } catch (e: Throwable) {
-                TileService.requestListeningState(this@TunnelToggleActivity, ComponentName(this@TunnelToggleActivity, QuickTileService::class.java))
+                updateTileService()
                 val error = ErrorMessages[e]
                 val message = getString(R.string.toggle_error, error)
                 Log.e(TAG, message, e)
@@ -41,8 +50,18 @@ class TunnelToggleActivity : AppCompatActivity() {
                 finishAffinity()
                 return@launch
             }
-            TileService.requestListeningState(this@TunnelToggleActivity, ComponentName(this@TunnelToggleActivity, QuickTileService::class.java))
+            updateTileService()
             finishAffinity()
+        }
+    }
+
+    /**
+     * TileService is only available for API 24+, if it's available it'll be updated,
+     * otherwise it's ignored.
+     */
+    private fun updateTileService() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            TileService.requestListeningState(this@TunnelToggleActivity, ComponentName(this@TunnelToggleActivity, QuickTileService::class.java))
         }
     }
 

--- a/ui/src/main/java/com/wireguard/android/fragment/BaseFragment.kt
+++ b/ui/src/main/java/com/wireguard/android/fragment/BaseFragment.kt
@@ -7,6 +7,7 @@ package com.wireguard.android.fragment
 import android.content.Context
 import android.util.Log
 import android.view.View
+import android.widget.CompoundButton
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.databinding.DataBindingUtil
@@ -105,6 +106,18 @@ abstract class BaseFragment : Fragment(), OnSelectedTunnelChangedListener {
                     Toast.makeText(activity, message, Toast.LENGTH_LONG).show()
                 Log.e(TAG, message, e)
             }
+        }
+    }
+
+    fun setShortcutState(view: CompoundButton, checked: Boolean) {
+        val tunnel = when (val binding = DataBindingUtil.findBinding<ViewDataBinding>(view)) {
+            is TunnelDetailFragmentBinding -> binding.tunnel
+            is TunnelListItemBinding -> binding.item
+            else -> return
+        } ?: return
+        val activity = activity ?: return
+        activity.lifecycleScope.launch {
+            tunnel.setShortcutsAsync(checked)
         }
     }
 

--- a/ui/src/main/java/com/wireguard/android/model/ObservableTunnel.kt
+++ b/ui/src/main/java/com/wireguard/android/model/ObservableTunnel.kt
@@ -139,6 +139,24 @@ class ObservableTunnel internal constructor(
 
     suspend fun deleteAsync() = manager.delete(this)
 
+    suspend fun setShortcutsAsync(hasShortcuts: Boolean) = manager.setShortcuts(this, hasShortcuts)
+
+    @get:Bindable
+    var hasShortcut: Boolean? = null
+        get() {
+            if (field == null)
+            // Opportunistically fetch this if we don't have a cached one, and rely on data bindings to update it eventually
+                applicationScope.launch {
+                    try {
+                        field = manager.hasShortcut(this@ObservableTunnel)
+                    } catch (e: Throwable) {
+                        Log.e(TAG, Log.getStackTraceString(e))
+                    }
+                }
+            return field
+        }
+        private set
+
 
     companion object {
         private const val TAG = "WireGuard/ObservableTunnel"

--- a/ui/src/main/java/com/wireguard/android/model/ShortcutManager.kt
+++ b/ui/src/main/java/com/wireguard/android/model/ShortcutManager.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017-2022 WireGuard LLC. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.wireguard.android.model
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import com.wireguard.android.BuildConfig
+import com.wireguard.android.R
+import com.wireguard.android.activity.TunnelToggleActivity
+
+class ShortcutManager(private val context: Context) {
+
+    private fun upIdFor(name: String): String = "$name-UP"
+    private fun downIdFor(name: String): String = "$name-DOWN"
+
+    private fun createShortcutIntent(action: String, tunnelName: String): Intent =
+        Intent(context, TunnelToggleActivity::class.java).apply {
+        setPackage(BuildConfig.APPLICATION_ID)
+        setAction(action)
+        putExtra("tunnel", tunnelName)
+    }
+
+    fun addShortcuts(name: String) {
+        val upIntent = createShortcutIntent("com.wireguard.android.action.SET_TUNNEL_UP", name)
+        val shortcutUp = ShortcutInfoCompat.Builder(context, upIdFor(name))
+            .setShortLabel(context.getString(R.string.shortcut_label_short_up, name))
+            .setLongLabel(context.getString(R.string.shortcut_label_long_up, name))
+            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_baseline_arrow_circle_up_24))
+            .setIntent(upIntent)
+            .build()
+        ShortcutManagerCompat.pushDynamicShortcut(context, shortcutUp)
+
+        val downIntent = createShortcutIntent("com.wireguard.android.action.SET_TUNNEL_DOWN", name)
+        val shortcutDown = ShortcutInfoCompat.Builder(context, downIdFor(name))
+            .setShortLabel(context.getString(R.string.shortcut_label_short_down, name))
+            .setLongLabel(context.getString(R.string.shortcut_label_long_down, name))
+            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_baseline_arrow_circle_down_24))
+            .setIntent(downIntent)
+            .build()
+        ShortcutManagerCompat.pushDynamicShortcut(context, shortcutDown)
+    }
+
+    fun removeShortcuts(name: String) {
+        ShortcutManagerCompat.removeDynamicShortcuts(context, listOf(upIdFor(name), downIdFor(name)))
+    }
+
+    fun hasShortcut(name: String) =
+        ShortcutManagerCompat.getDynamicShortcuts(context).any { it.id.startsWith(name) }
+}

--- a/ui/src/main/res/drawable/avd_star_to_border.xml
+++ b/ui/src/main/res/drawable/avd_star_to_border.xml
@@ -1,0 +1,22 @@
+<!--
+  ~ Copyright © 2017-2022 WireGuard LLC. All Rights Reserved.
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<animated-vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:drawable="@drawable/ic_baseline_star">
+
+    <target android:name="star">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:propertyName="pathData"
+                android:duration="300"
+                android:valueFrom="@string/vdpath_star_full"
+                android:valueTo="@string/vdpath_star_border"
+                android:valueType="pathType"
+                android:interpolator="@android:anim/accelerate_decelerate_interpolator"/>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/ui/src/main/res/drawable/avd_star_to_full.xml
+++ b/ui/src/main/res/drawable/avd_star_to_full.xml
@@ -1,0 +1,22 @@
+<!--
+  ~ Copyright © 2017-2022 WireGuard LLC. All Rights Reserved.
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<animated-vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:drawable="@drawable/ic_baseline_star_border">
+
+    <target android:name="star">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:propertyName="pathData"
+                android:duration="300"
+                android:valueFrom="@string/vdpath_star_border"
+                android:valueTo="@string/vdpath_star_full"
+                android:valueType="pathType"
+                android:interpolator="@android:anim/accelerate_decelerate_interpolator"/>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/ui/src/main/res/drawable/ic_action_shortcut.xml
+++ b/ui/src/main/res/drawable/ic_action_shortcut.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2017-2022 WireGuard LLC. All Rights Reserved.
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<animated-selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/star_full"
+        android:drawable="@drawable/ic_baseline_star"
+        android:state_checked="true"/>
+    <item
+        android:id="@+id/star_border"
+        android:drawable="@drawable/ic_baseline_star_border"
+        android:state_checked="false"/>
+
+    <transition
+        android:drawable="@drawable/avd_star_to_full"
+        android:fromId="@id/star_border"
+        android:toId="@id/star_full"/>
+
+    <transition
+        android:drawable="@drawable/avd_star_to_border"
+        android:fromId="@id/star_full"
+        android:toId="@id/star_border"/>
+
+</animated-selector>

--- a/ui/src/main/res/drawable/ic_baseline_arrow_circle_down_24.xml
+++ b/ui/src/main/res/drawable/ic_baseline_arrow_circle_down_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,4c4.41,0 8,3.59 8,8s-3.59,8 -8,8s-8,-3.59 -8,-8S7.59,4 12,4M12,2C6.48,2 2,6.48 2,12c0,5.52 4.48,10 10,10c5.52,0 10,-4.48 10,-10C22,6.48 17.52,2 12,2L12,2zM13,12l0,-4h-2l0,4H8l4,4l4,-4H13z"/>
+</vector>

--- a/ui/src/main/res/drawable/ic_baseline_arrow_circle_up_24.xml
+++ b/ui/src/main/res/drawable/ic_baseline_arrow_circle_up_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8s8,3.59 8,8S16.41,20 12,20M12,22c5.52,0 10,-4.48 10,-10c0,-5.52 -4.48,-10 -10,-10C6.48,2 2,6.48 2,12C2,17.52 6.48,22 12,22L12,22zM11,12l0,4h2l0,-4h3l-4,-4l-4,4H11z"/>
+</vector>

--- a/ui/src/main/res/drawable/ic_baseline_star.xml
+++ b/ui/src/main/res/drawable/ic_baseline_star.xml
@@ -1,0 +1,17 @@
+<!--
+  ~ Copyright © 2017-2022 WireGuard LLC. All Rights Reserved.
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24" >
+    <path
+        android:name="star"
+        android:fillColor="@android:color/white"
+        android:pathData="@string/vdpath_star_full"/>
+</vector>

--- a/ui/src/main/res/drawable/ic_baseline_star_border.xml
+++ b/ui/src/main/res/drawable/ic_baseline_star_border.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ Copyright © 2017-2022 WireGuard LLC. All Rights Reserved.
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:tint="#000000" >
+    <path
+        android:name="star"
+        android:fillColor="@android:color/white"
+        android:pathData="@string/vdpath_star_border"/>
+</vector>

--- a/ui/src/main/res/layout/tunnel_list_item.xml
+++ b/ui/src/main/res/layout/tunnel_list_item.xml
@@ -33,7 +33,7 @@
         android:background="@drawable/list_item_background"
         android:descendantFocusability="beforeDescendants"
         android:focusable="true"
-        android:nextFocusRight="@+id/tunnel_switch"
+        android:nextFocusRight="@+id/tunnel_shortcut_toggle"
         android:paddingHorizontal="16dp"
         android:paddingVertical="8dp">
 
@@ -48,6 +48,20 @@
             android:text="@{key}"
             android:textAppearance="?attr/textAppearanceBodyLarge"
             tools:text="@sample/interface_names.json/names/names/name" />
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/tunnel_shortcut_toggle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignBaseline="@id/tunnel_switch"
+            android:layout_toStartOf="@id/tunnel_switch"
+            android:button="@drawable/ic_action_shortcut"
+            android:checked="@{item.hasShortcut == true}"
+            android:nextFocusRight="@+id/tunnel_switch"
+            android:onCheckedChanged="@{fragment::setShortcutState}"
+            android:tooltipText="@string/tooltip_tunnel_shortcut"
+            app:buttonTint="?attr/colorSecondary"
+            tools:checked="@sample/interface_names.json/names/shortcut/shortcut" />
 
         <com.wireguard.android.widget.ToggleSwitch
             android:id="@+id/tunnel_switch"

--- a/ui/src/main/res/values/pathdata.xml
+++ b/ui/src/main/res/values/pathdata.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2017-2022 WireGuard LLC. All Rights Reserved.
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<resources>
+    <string name="vdpath_star_full" translatable="false">M 12 17.27 L 18.18 21 L 16.54 13.97 L 19.27 11.605 L 22 9.24 L 14.81 8.63 L 12 2 L 9.19 8.63 L 2 9.24 L 7.46 13.97 L 5.82 21 L 12 17.27 M 12.005 12.495 L 12.005 12.495 L 12.005 12.495 L 12.005 12.495 L 12.005 12.495 L 12.005 12.495 L 12.005 12.495 L 12.005 12.495 L 12.005 12.495 L 12.005 12.495 L 12.005 12.495 L 12.005 12.495</string>
+    <string name="vdpath_star_border" translatable="false">M 12 17.27 L 18.18 21 L 16.55 13.97 L 22 9.24 L 22 9.24 L 14.81 8.62 L 12 2 L 9.19 8.63 L 2 9.24 L 7.46 13.97 L 5.82 21 L 12 17.27 M 12 15.4 L 8.24 17.67 L 9.24 13.39 L 5.92 10.51 L 10.3 10.13 L 12 6.1 L 13.71 10.14 L 18.09 10.52 L 14.77 13.4 L 15.77 17.68 L 12 15.4 L 12 15.4</string>
+</resources>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -257,4 +257,9 @@
     <string name="biometric_prompt_private_key_title">Authenticate to view private key</string>
     <string name="biometric_auth_error">Authentication failure</string>
     <string name="biometric_auth_error_reason">Authentication failure: %s</string>
+    <string name="tooltip_tunnel_shortcut">Add shortcuts</string>
+    <string name="shortcut_label_short_up">%s UP</string>
+    <string name="shortcut_label_long_up">Tunnel %s up</string>
+    <string name="shortcut_label_short_down">%s DOWN</string>
+    <string name="shortcut_label_long_down">Tunnel %s down</string>
 </resources>


### PR DESCRIPTION
This is an updated version of the pull request https://github.com/WireGuard/wireguard-android/pull/48 to try to make it more likely to be merged.

The hard work was done by @gergely-sallai Gergely Sallai in their fork. I have tweaked it as follows:
- update to compile against the current master branch
- made a small cosmetic change to the alignment of the UI component
- squashed into a single commit for simplicity

I hope this is the right way to get this merged and that I haven't broken any github etiquette!

Original pull request information reproduced below:

Added support for [Android Dynamic Shortcuts](https://developer.android.com/guide/topics/ui/shortcuts/creating-shortcuts#dynamic). Dynamic Shortcuts is a standard Android feature that is supported by most of the launchers.

**How does this work for users?**
Now users can request the app to add shortcuts to their favourite tunnels. When the user enables this for a specific tunnel, 2 dynamic shortcuts are created, one to UP the tunnel, other is to DOWN it.

Additionally this functionality enables users to use certain automation apps to automatically toggle tunnels. For example the built-in Bixby Routines on Samsung devices. (This was my original motivation for adding this feature, but I was trying to incorporate it in a way that could benefit all users.)

**What changes were made to previous components to support this?**
TunnelToggleActivity is now more broadly used. Previously it seemed to be only called from TileService in certain situations.
A new button has been added next to the tunnel toggle switch for each tunnel item.
Added androidx shortcuts library
Limitations and possible points for future improvement
To my best knowledge all of these -- expect the first point -- were there previous to my PR, and I can help to sort these out if needed.

Tooltip popup for the "add shortcuts" button is only available for devices running API 26 and up. This could be solved generally via TooltipCompat, but I didn't want to complicate the code because of this. As doing this with the compat lib can not be done purely from XML..
TunnelToggleActivity can be shown briefly when a tunnel is toggled, and it can look weird. This could possibly be solved by adding some design to the activity and showing it a bit longer in a controlled manner, maybe with some animation.
There may be some misconfigurations around material colors, it caused me some rendering differences on certain OS version with the button colors. I believe this could be solved with a refactor to support Material You (M3) and its dynamic colors, and fall back to a default on older versions. I do not know what is the intended design language of the app, so I didn't dare to refactor it just yet. :)