### PR TITLE
ui: only show a snackbar for Android 12 and lower

### DIFF
--- a/ui/src/main/java/com/wireguard/android/util/ClipboardUtils.kt
+++ b/ui/src/main/java/com/wireguard/android/util/ClipboardUtils.kt
@@ -6,6 +6,7 @@ package com.wireguard.android.util
 
 import android.content.ClipData
 import android.content.ClipboardManager
+import android.os.Build
 import android.view.View
 import android.widget.TextView
 import androidx.core.content.getSystemService
@@ -29,6 +30,8 @@ object ClipboardUtils {
         }
         val service = view.context.getSystemService<ClipboardManager>() ?: return
         service.setPrimaryClip(ClipData.newPlainText(data.second, data.first))
-        Snackbar.make(view, view.context.getString(R.string.copied_to_clipboard, data.second), Snackbar.LENGTH_LONG).show()
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+            Snackbar.make(view, view.context.getString(R.string.copied_to_clipboard, data.second), Snackbar.LENGTH_LONG).show()
+        }
     }
 }


### PR DESCRIPTION
Starting with Android 13, when copying something to the Clipboard it will show a toast by default. So it is no longer necessary to show a snackbar to the user again.

https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#duplicate-notifications