### PR TITLE
Added support for automatically disconnecting from a tunnel when connected to a specified Wi-Fi network.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 junit = "junit:junit:4.13.2"
 kotlinx-coroutines-android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.0"
 zxing-android-embedded = "com.journeyapps:zxing-android-embedded:4.3.0"
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version = "2.8.1" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/tunnel/src/main/java/com/wireguard/android/backend/Tunnel.java
+++ b/tunnel/src/main/java/com/wireguard/android/backend/Tunnel.java
@@ -54,4 +54,14 @@ public interface Tunnel {
             return running ? UP : DOWN;
         }
     }
+
+    /**
+     * Enum class to represent the reason for why a tunnel's state has changed
+     */
+    enum StateChangeReason {
+        USER_INTERACTION,
+        EXTERNAL_INTENT,
+        AUTO_START,
+        WIFI_WORKER;
+    }
 }

--- a/tunnel/src/main/java/com/wireguard/config/BadConfigException.java
+++ b/tunnel/src/main/java/com/wireguard/config/BadConfigException.java
@@ -99,7 +99,8 @@ public class BadConfigException extends Exception {
         MISSING_SECTION,
         SYNTAX_ERROR,
         UNKNOWN_ATTRIBUTE,
-        UNKNOWN_SECTION
+        UNKNOWN_SECTION,
+        INVALID_ADDITIONAL_CONFIG
     }
 
     public enum Section {

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -80,6 +80,7 @@ dependencies {
     implementation(libs.google.material)
     implementation(libs.zxing.android.embedded)
     implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.androidx.work.runtime.ktx)
     coreLibraryDesugaring(libs.desugarJdkLibs)
 }
 

--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -7,6 +7,11 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28"

--- a/ui/src/main/java/com/wireguard/android/model/ObservableTunnel.kt
+++ b/ui/src/main/java/com/wireguard/android/model/ObservableTunnel.kt
@@ -63,7 +63,7 @@ class ObservableTunnel internal constructor(
 
     suspend fun setStateAsync(state: Tunnel.State): Tunnel.State = withContext(Dispatchers.Main.immediate) {
         if (state != this@ObservableTunnel.state)
-            manager.setTunnelState(this@ObservableTunnel, state)
+            manager.setTunnelState(this@ObservableTunnel, state, Tunnel.StateChangeReason.USER_INTERACTION)
         else
             this@ObservableTunnel.state
     }

--- a/ui/src/main/java/com/wireguard/android/model/TunnelManager.kt
+++ b/ui/src/main/java/com/wireguard/android/model/TunnelManager.kt
@@ -315,7 +315,7 @@ class TunnelManager(private val configStore: ConfigStore) : BaseObservable() {
                     }
                     val manager = getTunnelManager()
                     val tunnels = manager.getTunnels().filter { tunnel ->
-                        tunnel.getConfigAsync().isAutoDisconnectEnabled && tunnel.getConfigAsync().autoDisconnectNetworks.contains(ssid)
+                        tunnel.getConfigAsync().isAutoDisconnectEnabled && tunnel.getConfigAsync().autoDisconnectNetworks.split(",").any{ it.trim() == ssid }
                     }
                     tunnels.forEach { tunnel ->
                         try {

--- a/ui/src/main/res/layout/tunnel_detail_fragment.xml
+++ b/ui/src/main/res/layout/tunnel_detail_fragment.xml
@@ -304,6 +304,55 @@
                 </androidx.constraintlayout.widget.ConstraintLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/tunnel_wifi_detail_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginBottom="8dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tunnel_detail_card">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/wifi_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/wifi_settings"
+                        android:textAppearance="?attr/textAppearanceTitleMedium"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <TextView
+                        android:id="@+id/wifi_auto_disconnect_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:labelFor="@+id/wifi_auto_disconnect_text"
+                        android:text="@string/blacklisted_wifi_networks"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/wifi_title" />
+
+                    <TextView
+                        android:id="@+id/wifi_auto_disconnect_text"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:contentDescription="@string/blacklisted_wifi_networks"
+                        android:onClick="@{ClipboardUtils::copyTextView}"
+                        android:text="@{config.autoDisconnectEnabled ? config.autoDisconnectNetworks : @string/wifi_auto_disconnect_disabled}"
+                        android:textAppearance="?attr/textAppearanceBodyLarge"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/wifi_auto_disconnect_label"
+                        tools:text="Network 1" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </com.google.android.material.card.MaterialCardView>
+
             <LinearLayout
                 android:id="@+id/peers_layout"
                 android:layout_width="match_parent"
@@ -314,7 +363,7 @@
                 app:items="@{config.peers}"
                 app:layout="@{@layout/tunnel_detail_peer}"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tunnel_detail_card"
+                app:layout_constraintTop_toBottomOf="@+id/tunnel_wifi_detail_card"
                 tools:ignore="UselessLeaf" />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/ui/src/main/res/layout/tunnel_editor_fragment.xml
+++ b/ui/src/main/res/layout/tunnel_editor_fragment.xml
@@ -261,6 +261,62 @@
                             tools:text="4 excluded applications" />
                     </androidx.constraintlayout.widget.ConstraintLayout>
                 </com.google.android.material.card.MaterialCardView>
+                <com.google.android.material.card.MaterialCardView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginBottom="16dp">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/wifi_config_title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_margin="8dp"
+                            android:layout_marginTop="32dp"
+                            android:text="@string/wifi_settings"
+                            android:textAppearance="?attr/textAppearanceTitleMedium"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent" />
+                        <com.google.android.material.checkbox.MaterialCheckBox
+                            android:id="@+id/auto_disconnect_checkbox"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:checked="@={config.enableAutoDisconnect}"
+                            android:text="@string/wifi_auto_disconnect_checkbox"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toBottomOf="@id/wifi_config_title" />
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:id="@+id/auto_disconnect_wifi_label_layout"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_margin="4dp"
+                            android:hint="@string/auto_disconnect_networks_label"
+                            app:expandedHintEnabled="false"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toBottomOf="@+id/auto_disconnect_checkbox">
+
+                            <com.google.android.material.textfield.TextInputEditText
+                                android:id="@+id/auto_disconnect_networks_text"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:ellipsize="end"
+                                android:hint="@string/auto_disconnect_networks_hint"
+                                android:imeOptions="actionNext"
+                                android:nextFocusUp="@id/private_key_text"
+                                android:singleLine="true"
+                                android:enabled="@{config.enableAutoDisconnect}"
+                                android:text="@={config.autoDisconnectNetworks}" />
+                        </com.google.android.material.textfield.TextInputLayout>
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+                </com.google.android.material.card.MaterialCardView>
 
                 <LinearLayout
                     android:id="@+id/peers_layout"

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -257,4 +257,10 @@
     <string name="biometric_prompt_private_key_title">Authenticate to view private key</string>
     <string name="biometric_auth_error">Authentication failure</string>
     <string name="biometric_auth_error_reason">Authentication failure: %s</string>
+    <string name="wifi_settings">Wi-Fi Settings</string>
+    <string name="wifi_auto_disconnect_checkbox">Disconnect when using to one of these networks:</string>
+    <string name="auto_disconnect_networks_hint">Network1, Network2, Network3</string>
+    <string name="auto_disconnect_networks_label">Networks</string>
+    <string name="blacklisted_wifi_networks">Blacklisted Wi-Fi networks</string>
+    <string name="wifi_auto_disconnect_disabled">&lt;Disabled&gt;</string>
 </resources>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -263,4 +263,8 @@
     <string name="auto_disconnect_networks_label">Networks</string>
     <string name="blacklisted_wifi_networks">Blacklisted Wi-Fi networks</string>
     <string name="wifi_auto_disconnect_disabled">&lt;Disabled&gt;</string>
+    <string name="wifi_location_needed_message">To use the auto-disconnect feature, you need to enable fine location access for this application.</string>
+    <string name="wifi_location_needed_title">Location permissions needed</string>
+    <string name="wifi_location_ok">Ok</string>
+    <string name="wifi_location_cancel">Cancel</string>
 </resources>


### PR DESCRIPTION
Added support for automatically disconnecting from a tunnel when connected to a specified Wi-Fi network.

# How does this work for users?

Now when editing a tunnel, there's a field in which the user can enter the names of networks, connecting to which will cause this tunnel to be disconnected.
There's also a checkbox that will enable or disable this functionality for this particular tunnel.

# What changes were made to previous components to support this?

1. In tunnel: Two new config fields were added:
    - enableAutoDisconnect (boolean) - whether or not the feature is enabled
    - autoDisconnectNetworks (string) - the comma separated list of SSIDs
    These values are stored in the WgQuick config as comments following the scheme `ADD;key;value`:
    ```
    #ADD;wifi_auto_disconnect;<1 or 0 - enabled or disabled>
    #ADD;wifi_auto_disconnect_networks;<networks>
    ```
2. In ui:
    - Added the libs.androidx.work.runtime.ktx library for Job Scheduling
    - ConfigProxy was reworked to add the two aforementioned config fields
    - tunnel_detail_fragment and tunnel_editor_fragment now have separate sections for this feature
    - Added the required permissions in Android Manifest (Location permissions are needed in order to get the SSID of currently active Wi-Fi connection)
    - TunnelManager now contains the code for the worker which detaches and (re)attaches a new NetworkCallback every 15 minutes, so that android doesn't kill it. The worker is started and stopped depending on whether or not a tunnel with the feature enabled is active. If the last tunnel which uses this feature is DOWNed, the worker will be cancelled. If there are no tunnels which use this feature, the worker will not be started.
    - TunnelEditorFragment now contains the code for checking the location permission, needed for requesting the SSID. If the user refuses to grant the permission, the feature will be disabled.

# Limitations and possible points for future improvement

- The way this feature stores data in the tunnel config files could be improved - I am storing them as specially formatted comments, so that there will be no conflicts with any other software that might use WgQuick-formatted tunnel config files. 

# Why was this added?

If NAT hairpinning doesn't work correctly in a Wi-Fi network, and there is a tunnel to that same network open, all packets will go through Wireguard, and eventually get dropped. With this feature active, the Wireguard app will terminate the tunnel once the user connects to that network, and, as a result, the user will still have an internet connection.
This is already a feature in the iOS app, but there it has more features (it can f.ex. auto-connect to a tunnel when connected to a certain network).