### PR TITLE
gradle: migrate publishing to Maven Central Portal

### DIFF
--- a/MAVEN_CENTRAL_MIGRATION.md
+++ b/MAVEN_CENTRAL_MIGRATION.md
@@ -1,0 +1,142 @@
+# Maven Central Publishing Migration Guide
+
+This document outlines the migration from OSSRH to Maven Central Portal for publishing the WireGuard Android library.
+
+## Background
+
+OSSRH (OSS Repository Hosting) reached end-of-life on June 30, 2025. Maven Central has transitioned to a new Central Portal with redesigned APIs. The legacy Gradle publishing configuration in this project has been updated to use the new system.
+
+## Changes Made
+
+### 1. Plugin Update
+- **Old**: Manual `maven-publish` and `signing` plugins
+- **New**: `com.vanniktech.maven.publish` plugin v0.34.0
+
+### 2. Configuration Migration
+The publishing configuration has been completely replaced:
+
+**Before** (tunnel/build.gradle.kts):
+```kotlin
+plugins {
+    alias(libs.plugins.android.library)
+    `maven-publish`
+    signing
+}
+
+publishing {
+    publications {
+        register<MavenPublication>("release") {
+            // Complex manual configuration
+        }
+    }
+    repositories {
+        maven {
+            name = "sonatype"
+            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+            credentials {
+                username = providers.environmentVariable("SONATYPE_USER").orNull
+                password = providers.environmentVariable("SONATYPE_PASSWORD").orNull
+            }
+        }
+    }
+}
+
+signing {
+    useGpgCmd()
+    sign(publishing.publications)
+}
+```
+
+**After**:
+```kotlin
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.maven.publish)
+}
+
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+
+    coordinates(pkg, "tunnel", providers.gradleProperty("wireguardVersionName").get())
+
+    pom {
+        // Same POM configuration as before
+    }
+}
+```
+
+## Migration Steps for Maintainers
+
+### 1. Central Portal Account Setup
+1. Visit [central.sonatype.com](https://central.sonatype.com)
+2. Create account with same email used for OSSRH
+3. Click "Migrate Namespace" for existing namespaces
+4. Generate User Token in account settings
+
+### 2. Update Environment Variables
+Replace OSSRH credentials with Central Portal tokens:
+
+**Old variables**:
+- `SONATYPE_USER`
+- `SONATYPE_PASSWORD`
+
+**New variables**:
+- `ORG_GRADLE_PROJECT_mavenCentralUsername` (from Central Portal User Token)
+- `ORG_GRADLE_PROJECT_mavenCentralPassword` (from Central Portal User Token)
+
+### 3. GPG Configuration
+GPG signing setup remains the same:
+- `ORG_GRADLE_PROJECT_signingInMemoryKey` (base64 encoded private key)
+- `ORG_GRADLE_PROJECT_signingInMemoryKeyPassword` (key passphrase)
+
+## Publishing Commands
+
+### Manual Publishing (requires web portal approval)
+```bash
+./gradlew :tunnel:publishToMavenCentral
+```
+Then approve release in Central Portal web interface.
+
+### Automatic Publishing (recommended)
+```bash
+./gradlew :tunnel:publishAndReleaseToMavenCentral
+```
+Publishes and automatically releases without manual approval.
+
+### Snapshot Publishing
+```bash
+./gradlew :tunnel:publishToMavenCentral
+```
+Snapshots are automatically available without approval.
+
+## Validation
+
+After publishing, artifacts should be available at:
+- Releases: `https://repo1.maven.org/maven2/com/wireguard/android/tunnel/`
+- Snapshots: `https://s01.oss.sonatype.org/content/repositories/snapshots/com/wireguard/android/tunnel/`
+
+## Benefits of New System
+
+1. **Simplified Configuration**: Less boilerplate code
+2. **Improved Developer Experience**: Better error messages and documentation
+3. **Modern APIs**: More reliable and faster publishing
+4. **Automatic Release**: Optional auto-release eliminates manual approval step
+5. **Better Security**: Enhanced token-based authentication
+
+## Troubleshooting
+
+### Common Issues
+1. **Authentication Failures**: Verify Central Portal credentials are correctly set
+2. **Signing Errors**: Ensure GPG key is properly configured and accessible
+3. **Namespace Issues**: Confirm namespace migration completed in Central Portal
+
+### Getting Help
+- Central Portal Support: central-support@sonatype.com
+- Plugin Documentation: https://vanniktech.github.io/gradle-maven-publish-plugin/
+- Gradle Community Slack: #maven-central-publishing channel
+
+## References
+- [Maven Central Portal Documentation](https://central.sonatype.org/publish/publish-portal-gradle/)
+- [Vanniktech Plugin Documentation](https://vanniktech.github.io/gradle-maven-publish-plugin/)
+- [OSSRH Sunset Notice](https://central.sonatype.org/pages/ossrh-eol/)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,3 +27,4 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+maven-publish = { id = "com.vanniktech.maven.publish", version = "0.34.0" }

--- a/tunnel/build.gradle.kts
+++ b/tunnel/build.gradle.kts
@@ -6,8 +6,7 @@ val pkg: String = providers.gradleProperty("wireguardPackageName").get()
 
 plugins {
     alias(libs.plugins.android.library)
-    `maven-publish`
-    signing
+    alias(libs.plugins.maven.publish)
 }
 
 android {
@@ -57,12 +56,6 @@ android {
         disable += "LongLogTag"
         disable += "NewApi"
     }
-    publishing {
-        singleVariant("release") {
-            withJavadocJar()
-            withSourcesJar()
-        }
-    }
 }
 
 dependencies {
@@ -72,58 +65,38 @@ dependencies {
     testImplementation(libs.junit)
 }
 
-publishing {
-    publications {
-        register<MavenPublication>("release") {
-            groupId = pkg
-            artifactId = "tunnel"
-            version = providers.gradleProperty("wireguardVersionName").get()
-            afterEvaluate {
-                from(components["release"])
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+
+    coordinates(pkg, "tunnel", providers.gradleProperty("wireguardVersionName").get())
+
+    pom {
+        name = "WireGuard Tunnel Library"
+        description = "Embeddable tunnel library for WireGuard for Android"
+        url = "https://www.wireguard.com/"
+
+        licenses {
+            license {
+                name = "The Apache Software License, Version 2.0"
+                url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "repo"
             }
-            pom {
-                name = "WireGuard Tunnel Library"
-                description = "Embeddable tunnel library for WireGuard for Android"
+        }
+        scm {
+            connection = "scm:git:https://git.zx2c4.com/wireguard-android"
+            developerConnection = "scm:git:https://git.zx2c4.com/wireguard-android"
+            url = "https://git.zx2c4.com/wireguard-android"
+        }
+        developers {
+            organization {
+                name = "WireGuard"
                 url = "https://www.wireguard.com/"
-
-                licenses {
-                    license {
-                        name = "The Apache Software License, Version 2.0"
-                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                        distribution = "repo"
-                    }
-                }
-                scm {
-                    connection = "scm:git:https://git.zx2c4.com/wireguard-android"
-                    developerConnection = "scm:git:https://git.zx2c4.com/wireguard-android"
-                    url = "https://git.zx2c4.com/wireguard-android"
-                }
-                developers {
-                    organization {
-                        name = "WireGuard"
-                        url = "https://www.wireguard.com/"
-                    }
-                    developer {
-                        name = "WireGuard"
-                        email = "team@wireguard.com"
-                    }
-                }
+            }
+            developer {
+                name = "WireGuard"
+                email = "team@wireguard.com"
             }
         }
     }
-    repositories {
-        maven {
-            name = "sonatype"
-            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-            credentials {
-                username = providers.environmentVariable("SONATYPE_USER").orNull
-                password = providers.environmentVariable("SONATYPE_PASSWORD").orNull
-            }
-        }
-    }
-}
-
-signing {
-    useGpgCmd()
-    sign(publishing.publications)
 }


### PR DESCRIPTION
OSSRH reached end-of-life on June 30, 2025, breaking the current Maven Central publishing process. This PR updates the
publishing configuration to use the new Central Portal via the vanniktech/gradle-maven-publish-plugin.

Changes:
- Replace manual maven-publish/signing setup with vanniktech plugin
- Update from legacy OSSRH URLs to Central Portal APIs
- Maintain all existing POM metadata and artifact structure
- Add migration documentation

This enables publishing the 16KB page size compatibility fixes requested for Android 15+ compliance.  This change exists on https://git.zx2c4.com/wireguard-android/ already but is being held up by this Maven migration.  I exchanged a few emails with @zx2c4 about this.

I tested as far as I could using dryRun without actually pushing anything to Maven.